### PR TITLE
Ascii only

### DIFF
--- a/RomanNumerals/Numerals/NumeralsSet.cs
+++ b/RomanNumerals/Numerals/NumeralsSet.cs
@@ -124,9 +124,9 @@ public class NumeralsSet
         MaximumLength = new[]
         {
             _numeralsByValue.Values.SelectMany(n => n).Select(n=>n.Literal.Length).Max(),
-            _unicodeAliases.Keys.Select(n=>n.Length).Max(),
-            _unicodeAliases.Values.Select(n=>n.Length).Max(),
-            _ligatures.Keys.Select(n=>n.Length).Max(),
+            _unicodeAliases.Keys.Select(n=>n.Length).DefaultIfEmpty().Max(),
+            _unicodeAliases.Values.Select(n=>n.Length).DefaultIfEmpty().Max(),
+            _ligatures.Keys.Select(n=>n.Length).DefaultIfEmpty().Max(),
         }.Max();
     }
 

--- a/RomanNumerals/Numerals/NumeralsSet.cs
+++ b/RomanNumerals/Numerals/NumeralsSet.cs
@@ -115,6 +115,14 @@ public class NumeralsSet
             });
     }
 
+    public NumeralsSet(IEnumerable<Numeral> numerals) : this (
+        10,
+        numerals,
+        new Dictionary<string, string>(),
+        new Dictionary<string, string>()
+    ) {
+    }
+
     public NumeralsSet(uint @base, IEnumerable<Numeral> numerals, IDictionary<string, string> unicodeAliases, IDictionary<string, string> ligatures)
     {
         Base = @base;

--- a/RomanNumeralsTest/FromNumeralsTests.cs
+++ b/RomanNumeralsTest/FromNumeralsTests.cs
@@ -2,7 +2,6 @@
 using NUnit.Framework;
 using RomanNumerals;
 using RomanNumerals.Numerals;
-using System.Collections.Immutable;
 
 namespace RomanNumeralsTest;
 
@@ -90,7 +89,6 @@ public class FromNumeralsTests
     {
         var numeralsSet =
             new NumeralsSet(
-                10,
                 new Numeral[]
                 {
                     new("I", 1U, NumeralKind.Any),
@@ -100,9 +98,7 @@ public class FromNumeralsTests
                     new("C", 100U, NumeralKind.Any),
                     new("D", 500U, NumeralKind.Any),
                     new("M", 1000U, NumeralKind.Any),
-                },
-                ImmutableDictionary<string, string>.Empty,
-                ImmutableDictionary<string, string>.Empty
+                }
             );
         var v = NumeralParser.Default.TryParse(literalRoman, out var x, numeralsSet);
         Assert.AreEqual(expectedValue, v ? x : null);

--- a/RomanNumeralsTest/FromNumeralsTests.cs
+++ b/RomanNumeralsTest/FromNumeralsTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using NUnit.Framework;
 using RomanNumerals;
+using RomanNumerals.Numerals;
+using System.Collections.Immutable;
 
 namespace RomanNumeralsTest;
 
@@ -73,5 +75,36 @@ public class FromNumeralsTests
     {
         var v = literalRoman.FromRomanNumerals();
         Assert.AreEqual(expectedValue, v);
+    }
+
+    [Test]
+    [Property("Class", "AsciiOnly")]
+    [TestCase("I", 1u)]
+    [TestCase("MMXIX", 2019u)]
+    [TestCase("MDCLXVI", 1666u)]
+    [TestCase("CDXLIV", 444u)]
+    [TestCase("V\u0305I\u0305V", null)]
+    [TestCase("Ⅻ", null)]
+    [TestCase("ↀⅠ", null)]
+    public void ParseAsciiOnlyTest(string literalRoman, uint? expectedValue)
+    {
+        var numeralsSet =
+            new NumeralsSet(
+                10,
+                new Numeral[]
+                {
+                    new("I", 1U, NumeralKind.Any),
+                    new("V", 5U, NumeralKind.Any),
+                    new("X", 10U, NumeralKind.Any),
+                    new("L", 50U, NumeralKind.Any),
+                    new("C", 100U, NumeralKind.Any),
+                    new("D", 500U, NumeralKind.Any),
+                    new("M", 1000U, NumeralKind.Any),
+                },
+                ImmutableDictionary<string, string>.Empty,
+                ImmutableDictionary<string, string>.Empty
+            );
+        var v = NumeralParser.Default.TryParse(literalRoman, out var x, numeralsSet);
+        Assert.AreEqual(expectedValue, v ? x : null);
     }
 }


### PR DESCRIPTION
I wanted to create a ascii only and case insensitive, but it crashes when unicodeAliases or ligatures are empty.

The first commit fixes that.

The second (optional commit) does add a simpler way to create a simple set.
(The ImmutableDictionary<string, string>.Empty can't be used in the library because of the different LangVersion.)
